### PR TITLE
Parsers trait

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ project/plugins/project/
 .scala_dependencies
 .worksheet
 .idea
+.ensime
+.ensime_cache/

--- a/build.sbt
+++ b/build.sbt
@@ -8,5 +8,7 @@ lazy val root = (project in file(".")).
       version      := "0.1.0-SNAPSHOT"
     )),
     name := "transfigure",
+    scalacOptions += "-Ypartial-unification",
+    libraryDependencies += "org.typelevel" %% "cats-core" % "1.0.1",
     libraryDependencies += scalaTest % Test
   )

--- a/src/main/scala/example/Hello.scala
+++ b/src/main/scala/example/Hello.scala
@@ -1,9 +1,0 @@
-package example
-
-object Hello extends Greeting with App {
-  println(greeting)
-}
-
-trait Greeting {
-  lazy val greeting: String = "hello"
-}

--- a/src/main/scala/net/reasoning/transfigure/Parser.scala
+++ b/src/main/scala/net/reasoning/transfigure/Parser.scala
@@ -1,0 +1,27 @@
+package net.reasoning.transfigure
+
+trait Parsers {
+
+  type Input = ReaderStream[Elem]
+  type Elem
+
+  case class ParserError(message: String)
+
+  type ParserResult[+T] = Either[ParserError, (T, Input)]
+
+  abstract class Parser[+T] extends (Input => ParserResult[T]) {
+    def apply(in: Input): ParserResult[T]
+  }
+
+  def unit[T](a: T): Parser[T] = input => Right((a, input))
+}
+
+trait StringParsers extends Parsers {
+  type Elem = Char
+
+  def string(str: String): Parser[String] = input => {
+    if (input.startsWith(str)) Right((str, input.advance(str.length)))
+    else Left(ParserError(s"Expected $str"))
+  }
+
+}

--- a/src/main/scala/net/reasoning/transfigure/Parsers.scala
+++ b/src/main/scala/net/reasoning/transfigure/Parsers.scala
@@ -1,7 +1,8 @@
 package net.reasoning.transfigure
 
 import scala.util.matching.Regex
-
+import cats.Applicative
+import cats.syntax.applicative._
 
 trait Parsers {
 
@@ -16,7 +17,46 @@ trait Parsers {
     def apply(in: Input): ParserResult[T]
   }
 
-  def unit[T](a: T): Parser[T] = input => Right((a, input))
+  implicit val parserApplicative: Applicative[Parser] =
+    new Applicative[Parser] {
+      def pure[A](a: A):Parser[A] = input => Right((a, input))
+
+      override def map[A,B](pa: Parser[A])(f: A => B): Parser[B] = input => {
+        pa(input).map(res => (f(res._1), res._2))
+      }
+
+      def ap[A,B](pf: Parser[A => B])(pa: Parser[A]): Parser[B] = input => {
+        pf(input) match {
+          case Right((f, in)) => map(pa)(f)(in)
+          case Left(e)    => Left(e)
+        }
+      }
+    }
+
+  def unit[T](a: T)(implicit app: Applicative[Parser]): Parser[T] = app.pure(a)
+
+  def pure[T](a: T)(implicit app: Applicative[Parser]): Parser[T] = app.pure(a)
+  def pure[A,B,C](a: Function2[A,B,C])(implicit app: Applicative[Parser]) = app.pure(a.curried)
+  def pure[A,B,C,D](a: Function3[A,B,C,D])(implicit app: Applicative[Parser]) = app.pure(a.curried)
+  def pure[A,B,C,D,E](a: Function4[A,B,C,D,E])(implicit app: Applicative[Parser]) = app.pure(a.curried)
+  def pure[A,B,C,D,E,F](a: Function5[A,B,C,D,E,F])(implicit app: Applicative[Parser]) = app.pure(a.curried)
+  def pure[A,B,C,D,E,F,G](a: Function6[A,B,C,D,E,F,G])(implicit app: Applicative[Parser]) = app.pure(a.curried)
+  def pure[A,B,C,D,E,F,G,H](a: Function7[A,B,C,D,E,F,G,H])(implicit app: Applicative[Parser]) = app.pure(a.curried)
+  def pure[A,B,C,D,E,F,G,H,I](a: Function8[A,B,C,D,E,F,G,H,I])(implicit app: Applicative[Parser]) = app.pure(a.curried)
+  def pure[A,B,C,D,E,F,G,H,I,J](a: Function9[A,B,C,D,E,F,G,H,I,J])(implicit app: Applicative[Parser]) = app.pure(a.curried)
+  def pure[A,B,C,D,E,F,G,H,I,J,K](a: Function10[A,B,C,D,E,F,G,H,I,J,K])(implicit app: Applicative[Parser]) = app.pure(a.curried)
+  def pure[A,B,C,D,E,F,G,H,I,J,K,L](a: Function11[A,B,C,D,E,F,G,H,I,J,K,L])(implicit app: Applicative[Parser]) = app.pure(a.curried)
+  def pure[A,B,C,D,E,F,G,H,I,J,K,L,M](a: Function12[A,B,C,D,E,F,G,H,I,J,K,L,M])(implicit app: Applicative[Parser]) = app.pure(a.curried)
+  def pure[A,B,C,D,E,F,G,H,I,J,K,L,M,N](a: Function13[A,B,C,D,E,F,G,H,I,J,K,L,M,N])(implicit app: Applicative[Parser]) = app.pure(a.curried)
+  def pure[A,B,C,D,E,F,G,H,I,J,K,L,M,N,O](a: Function14[A,B,C,D,E,F,G,H,I,J,K,L,M,N,O])(implicit app: Applicative[Parser]) = app.pure(a.curried)
+  def pure[A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P](a: Function15[A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P])(implicit app: Applicative[Parser]) = app.pure(a.curried)
+  def pure[A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q](a: Function16[A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q])(implicit app: Applicative[Parser]) = app.pure(a.curried)
+  def pure[A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R](a: Function17[A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R])(implicit app: Applicative[Parser]) = app.pure(a.curried)
+  def pure[A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S](a: Function18[A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S])(implicit app: Applicative[Parser]) = app.pure(a.curried)
+  def pure[A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T](a: Function19[A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T])(implicit app: Applicative[Parser]) = app.pure(a.curried)
+  def pure[A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U](a: Function20[A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U])(implicit app: Applicative[Parser]) = app.pure(a.curried)
+  def pure[A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V](a: Function21[A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V])(implicit app: Applicative[Parser]) = app.pure(a.curried)
+  def pure[A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W](a: Function22[A,B,C,D,E,F,G,H,I,J,K,L,M,N,O,P,Q,R,S,T,U,V,W])(implicit app: Applicative[Parser]) = app.pure(a.curried)
 }
 
 trait StringParsers extends Parsers {

--- a/src/main/scala/net/reasoning/transfigure/Parsers.scala
+++ b/src/main/scala/net/reasoning/transfigure/Parsers.scala
@@ -1,8 +1,11 @@
 package net.reasoning.transfigure
 
+import scala.util.matching.Regex
+
+
 trait Parsers {
 
-  type Input = ReaderStream[Elem]
+  type Input
   type Elem
 
   case class ParserError(message: String)
@@ -18,10 +21,10 @@ trait Parsers {
 
 trait StringParsers extends Parsers {
   type Elem = Char
+  type Input = StringReader
 
   def string(str: String): Parser[String] = input => {
-    if (input.startsWith(str)) Right((str, input.advance(str.length)))
+    if (input.stream.startsWith(str)) Right((str, input.advance(str.length)))
     else Left(ParserError(s"Expected $str"))
   }
-
 }

--- a/src/main/scala/net/reasoning/transfigure/Parsers.scala
+++ b/src/main/scala/net/reasoning/transfigure/Parsers.scala
@@ -28,3 +28,12 @@ trait StringParsers extends Parsers {
     else Left(ParserError(s"Expected $str"))
   }
 }
+
+trait RegexParsers extends StringParsers {
+  def regex(re: Regex): Parser[String] = input => {
+    re.findPrefixOf(input.stream) match {
+      case Some(s) => Right((s, input.advance(s.length)))
+      case _ => Left(ParserError(s"Couldn't match $re"))
+    }
+  }
+}

--- a/src/main/scala/net/reasoning/transfigure/Parsers.scala
+++ b/src/main/scala/net/reasoning/transfigure/Parsers.scala
@@ -15,6 +15,11 @@ trait Parsers {
 
   abstract class Parser[+T] extends (Input => ParserResult[T]) {
     def apply(in: Input): ParserResult[T]
+
+    def <|>[U >: T](p2: Parser[U]): Parser[U] = input => this(input) match {
+      case Right((res,in)) => Right((res,in))
+      case Left(_) => p2(input)
+    }
   }
 
   implicit val parserApplicative: Applicative[Parser] =

--- a/src/main/scala/net/reasoning/transfigure/ReaderStream.scala
+++ b/src/main/scala/net/reasoning/transfigure/ReaderStream.scala
@@ -1,9 +1,10 @@
 package net.reasoning.transfigure
 
-case class ReaderStream[T](input: Seq[T]) {
-
-  def startsWith(string: Seq[T]): Boolean = input.startsWith(string)
-
-  def advance(n: Int): ReaderStream[T] = new ReaderStream(input.drop(n))
-
+abstract class ReaderStream[T] {
+  def advance(n: Int): ReaderStream[T]
 }
+
+case class StringReader(stream: String) extends ReaderStream[Char] {
+  def advance(n: Int) = StringReader(stream.drop(n))
+}
+

--- a/src/main/scala/net/reasoning/transfigure/ReaderStream.scala
+++ b/src/main/scala/net/reasoning/transfigure/ReaderStream.scala
@@ -1,0 +1,9 @@
+package net.reasoning.transfigure
+
+case class ReaderStream[T](input: Seq[T]) {
+
+  def startsWith(string: Seq[T]): Boolean = input.startsWith(string)
+
+  def advance(n: Int): ReaderStream[T] = new ReaderStream(input.drop(n))
+
+}

--- a/src/test/scala/example/HelloSpec.scala
+++ b/src/test/scala/example/HelloSpec.scala
@@ -1,9 +1,0 @@
-package example
-
-import org.scalatest._
-
-class HelloSpec extends FlatSpec with Matchers {
-  "The Hello object" should "say hello" in {
-    Hello.greeting shouldEqual "hello"
-  }
-}

--- a/src/test/scala/net/reasoning/TransfigureString.scala
+++ b/src/test/scala/net/reasoning/TransfigureString.scala
@@ -83,4 +83,20 @@ class StringParser extends FunSuite with Inside {
       assert(e == "baz")
     }
   }
+
+  test("Alternative between parsers") {
+    object TestParser extends StringParsers {
+      def foo = string("foo")
+      def bar = string("bar")
+      def baz = string("baz")
+
+      def test = foo <|> bar <|> baz
+    }
+
+    val reader = StringReader("baz123")
+
+    inside(TestParser.test(reader)) { case Right((s, _)) =>
+      assert(s == "baz")
+    }
+  }
 }

--- a/src/test/scala/net/reasoning/TransfigureString.scala
+++ b/src/test/scala/net/reasoning/TransfigureString.scala
@@ -8,11 +8,11 @@ class StringParser extends FunSuite with Inside {
 
   test("StringParser can recognized a single character") {
     val strParser = new Object() with StringParsers
-    val reader = new ReaderStream("foobarbaz")
+    val reader = StringReader("foobarbaz")
     val foo = strParser.string("foo")
 
     val result = foo(reader)
-    inside(result) { case Right((str, ReaderStream(input))) =>
+    inside(result) { case Right((str, StringReader(input))) =>
       assert(str == "foo")
       assert(input.toString == "barbaz")
     }
@@ -20,10 +20,10 @@ class StringParser extends FunSuite with Inside {
 
   test("Unit lifts a value into the parser. It should not consume any input") {
     val parser = new Object() with StringParsers
-    val reader = new ReaderStream("foobar")
+    val reader = StringReader("foobar")
     val unitParser = parser.unit(123)
 
-    inside(unitParser(reader)) { case Right((v, ReaderStream(input))) =>
+    inside(unitParser(reader)) { case Right((v, StringReader(input))) =>
       assert(v == 123)
       assert(input.toString == "foobar")
     }

--- a/src/test/scala/net/reasoning/TransfigureString.scala
+++ b/src/test/scala/net/reasoning/TransfigureString.scala
@@ -8,19 +8,7 @@ import cats.Applicative
 import cats.implicits._
 import cats.syntax.applicative._
 
-class StringParser extends FunSuite with Inside {
-
-  test("StringParser can recognized a single character") {
-    val strParser = new Object() with StringParsers
-    val reader = StringReader("foobarbaz")
-    val foo = strParser.string("foo")
-
-    val result = foo(reader)
-    inside(result) { case Right((str, StringReader(input))) =>
-      assert(str == "foo")
-      assert(input.toString == "barbaz")
-    }
-  }
+class ParsersTest extends FunSuite with Inside {
 
   test("Unit lifts a value into the parser. It should not consume any input") {
     object TestParser extends StringParsers {
@@ -32,16 +20,6 @@ class StringParser extends FunSuite with Inside {
     inside(TestParser.unitParser(reader)) { case Right((v, StringReader(input))) =>
       assert(v == 123)
       assert(input.toString == "foobar")
-    }
-  }
-
-  test("Regex parser matches regex") {
-    val parser = new Object() with RegexParsers
-    val reader = StringReader("123foo")
-    val regexParser = parser.regex("(\\d+)".r)
-
-    inside(regexParser(reader)) { case Right((v, _)) =>
-      assert(v == "123")
     }
   }
 
@@ -99,4 +77,100 @@ class StringParser extends FunSuite with Inside {
       assert(s == "baz")
     }
   }
+
+  test("zero or one will match one") {
+    object TestParser extends StringParsers {
+      def foo = string("foo")
+      def test = foo.?
+    }
+
+    val reader = StringReader("foofoofoo")
+
+    inside(TestParser.test(reader)) { case Right((Some(s), _)) =>
+      assert(s == "foo")
+    }
+  }
+
+  test("zero or one will match zero") {
+    object TestParser extends StringParsers {
+      def foo = string("foo")
+      def test = foo.?
+    }
+
+    val reader = StringReader("barfoo")
+
+    val res = TestParser.test(reader)
+    inside(TestParser.test(reader)) { case Right((s, _)) =>
+      assert(s.isEmpty)
+    }
+  }
+
+  test("many will match many") {
+    object TestParser extends StringParsers {
+      def foo = string("foo")
+      def test = foo.*
+    }
+
+    val reader = StringReader("foofoofoobar")
+
+    inside(TestParser.test(reader)) { case Right((s, _)) =>
+      assert(s == List("foo", "foo", "foo"))
+    }
+  }
+
+  test("many will match zero") {
+    object TestParser extends StringParsers {
+      def foo = string("foo")
+      def test = foo.*
+    }
+
+    val reader = StringReader("barfoofoofoobar")
+
+    inside(TestParser.test(reader)) { case Right((s, _)) =>
+      assert(s.isEmpty)
+    }
+  }
+
+  test("oneOrMany will match many") {
+    object TestParser extends StringParsers {
+      def foo = string("foo")
+      def test = foo.+
+    }
+
+    val reader = StringReader("foofoofoobar")
+
+    inside(TestParser.test(reader)) { case Right((s, _)) =>
+      assert(s == List("foo", "foo", "foo"))
+    }
+  }
+}
+
+class StringParsersTest extends FunSuite with Inside {
+
+  test("StringParser can recognized a single character") {
+    val strParser = new Object() with StringParsers
+    val reader = StringReader("foobarbaz")
+    val foo = strParser.string("foo")
+
+    val result = foo(reader)
+    inside(result) { case Right((str, StringReader(input))) =>
+      assert(str == "foo")
+      assert(input.toString == "barbaz")
+    }
+  }
+
+}
+
+class RegexParsersTest extends FunSuite with Inside {
+
+  test("Regex parser matches regex") {
+    val parser = new Object() with RegexParsers
+    val reader = StringReader("123foo")
+    val regexParser = parser.regex("(\\d+)".r)
+
+    inside(regexParser(reader)) { case Right((v, _)) =>
+      assert(v == "123")
+    }
+  }
+  
 }

--- a/src/test/scala/net/reasoning/TransfigureString.scala
+++ b/src/test/scala/net/reasoning/TransfigureString.scala
@@ -28,4 +28,14 @@ class StringParser extends FunSuite with Inside {
       assert(input.toString == "foobar")
     }
   }
+
+  test("Regex parser matches regex") {
+    val parser = new Object() with RegexParsers
+    val reader = StringReader("123foo")
+    val regexParser = parser.regex("(\\d+)".r)
+
+    inside(regexParser(reader)) { case Right((v, _)) =>
+      assert(v == "123")
+    }
+  }
 }

--- a/src/test/scala/net/reasoning/TransfigureString.scala
+++ b/src/test/scala/net/reasoning/TransfigureString.scala
@@ -1,0 +1,31 @@
+package net.reasoning.transfigure.test
+
+import net.reasoning.transfigure._
+import org.scalatest.FunSuite
+import org.scalatest.Inside
+
+class StringParser extends FunSuite with Inside {
+
+  test("StringParser can recognized a single character") {
+    val strParser = new Object() with StringParsers
+    val reader = new ReaderStream("foobarbaz")
+    val foo = strParser.string("foo")
+
+    val result = foo(reader)
+    inside(result) { case Right((str, ReaderStream(input))) =>
+      assert(str == "foo")
+      assert(input.toString == "barbaz")
+    }
+  }
+
+  test("Unit lifts a value into the parser. It should not consume any input") {
+    val parser = new Object() with StringParsers
+    val reader = new ReaderStream("foobar")
+    val unitParser = parser.unit(123)
+
+    inside(unitParser(reader)) { case Right((v, ReaderStream(input))) =>
+      assert(v == 123)
+      assert(input.toString == "foobar")
+    }
+  }
+}


### PR DESCRIPTION
Adding the first functional Parsers trait that abstracts out the basic parser combinator library. This trait defines the interface for an abstract type Parser, that represents a parser from Input to ParseResult. It supports the pure to lift a value into the parser context and the basic combinators like * (many), ? (zero or one), + (one or more).

In addition, the abstract Parser type is an instance of the Applicative typeclass and therefore supports the development of parsers using the applicative style. At the moment, we do not implement Monad and therefore do not support context-sensitive languages.

No concrete Parsers are included and requires the library user to mix-in one of the Parsers traits. Currently, there is a basic StringsParsers and RegexParsers.